### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/yamls/github_yamls/100_nightly.yml
+++ b/yamls/github_yamls/100_nightly.yml
@@ -37,7 +37,7 @@ jobs:
             -t jinaai/jina:devel -t jinaai/jina:${{env.JINA_VERSION}} \
             --file ./Dockerfiles/debianx.Dockerfile .
       - name: Upload to Github Docker Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: jina-ai/jina/jina
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/yamls/github_yamls/103_cd.yml
+++ b/yamls/github_yamls/103_cd.yml
@@ -82,7 +82,7 @@ jobs:
           echo ::set-env name=INSTALL_DEV::"true"
           echo ::set-env name=JINA_VERSION::"$(sed '6q;d' ./jina/__init__.py | cut -d \' -f2)-devel"
       - name: Upload to Docker Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: jinaai/jina
           username: ${{ secrets.DOCKERHUB_DEVBOT_USER }}
@@ -91,7 +91,7 @@ jobs:
           buildargs: BUILD_DATE, VCS_REF, JINA_VERSION, INSTALL_DEV
           tags: "devel, ${{env.JINA_VERSION}}"
       - name: Upload to Github Docker Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: jina-ai/jina/jina
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/yamls/github_yamls/1238_release.yml
+++ b/yamls/github_yamls/1238_release.yml
@@ -143,7 +143,7 @@ jobs:
         run: echo ::set-env name=DOCKER_TAGS::$(echo ${{ steps.bump_dry.outputs.tag }})
 
       - name: "4. Build and publish docker to docker hub"
-        uses: elgohr/Publish-Docker-Github-Action@2.14
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: unit8/darts
           username: ${{ secrets.DOCKER_HUB_USER }}

--- a/yamls/github_yamls/1588_cd-docker-ui-preview.yml
+++ b/yamls/github_yamls/1588_cd-docker-ui-preview.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: ${{ env.ESQUIO_REPO }}/${{ env.IMAGE_NAME }}
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/yamls/github_yamls/1591_cd-docker-demo.yml
+++ b/yamls/github_yamls/1591_cd-docker-demo.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: ${{ env.REGISTRY }}/${{ env.ACR_REPO }}
         username: ${{ secrets.ESQUIO_DOCKER_USERNAME }}

--- a/yamls/github_yamls/1593_cd-docker-ui.yml
+++ b/yamls/github_yamls/1593_cd-docker-ui.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: ${{ env.ESQUIO_REPO }}/${{ env.IMAGE_NAME }}
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/yamls/github_yamls/1598_cd-docker-internal-demo.yml
+++ b/yamls/github_yamls/1598_cd-docker-internal-demo.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Publish to Registry internal demo app
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: ${{ env.REGISTRY }}/${{ env.ACR_REPO_APP }}
         username: ${{ secrets.ESQUIO_DOCKER_USERNAME }}
@@ -25,7 +25,7 @@ jobs:
         tags: "latest,${{ env.TAG }}"
 
     - name: Publish to Registry internal demo ui
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: ${{ env.REGISTRY }}/${{ env.ACR_REPO_UI }}
         username: ${{ secrets.ESQUIO_DOCKER_USERNAME }}

--- a/yamls/github_yamls/1657_inspektor-gadget.yml
+++ b/yamls/github_yamls/1657_inspektor-gadget.yml
@@ -28,7 +28,7 @@ jobs:
 
     - name: Build gadget container and publish to Registry
       id: publish-registry
-      uses: elgohr/Publish-Docker-Github-Action@2.8
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: ${{ secrets.CONTAINER_REPO }}
         username: ${{ secrets.CONTAINER_REGISTRY_USERNAME }}

--- a/yamls/github_yamls/1811_publish-docker-latest.yml
+++ b/yamls/github_yamls/1811_publish-docker-latest.yml
@@ -15,7 +15,7 @@ jobs:
         id: release
       - name: Publish to Registry
         if: steps.release.outputs.is_latest == 'true'
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: getmeili/meilisearch
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/yamls/github_yamls/1813_publish-docker-tag.yml
+++ b/yamls/github_yamls/1813_publish-docker-tag.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: getmeili/meilisearch
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/yamls/github_yamls/253_dockerhub-push.yml
+++ b/yamls/github_yamls/253_dockerhub-push.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Publish to Dockerhub Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: projectdiscovery/dnsprobe
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/yamls/github_yamls/279_docker-publish.yml
+++ b/yamls/github_yamls/279_docker-publish.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@master
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: borales/yarn
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/yamls/github_yamls/42_dockerhub-push.yml
+++ b/yamls/github_yamls/42_dockerhub-push.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Publish to Dockerhub Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: projectdiscovery/naabu
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/yamls/github_yamls/889_push.yml
+++ b/yamls/github_yamls/889_push.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Build Image
       run: docker build -t "${IMAGE}:${VERSION}" .
     - name: Push Image
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: "${{ env.IMAGE }}:${{ env.VERSION }}"
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/yamls/github_yamls/95_tag.yml
+++ b/yamls/github_yamls/95_tag.yml
@@ -86,7 +86,7 @@ jobs:
             -t "jinaai/jina:$JINA_VERSION" -t jinaai/jina:latest \
             --file ./Dockerfiles/debianx.Dockerfile .
       - name: Upload to Github Docker Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: jina-ai/jina/jina
           username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore